### PR TITLE
Add simpler check for git SHA

### DIFF
--- a/app/writer/procedure/ProcedureWriter.js
+++ b/app/writer/procedure/ProcedureWriter.js
@@ -45,8 +45,8 @@ module.exports = class ProcedureWriter extends Abstract {
 		if (fs.existsSync(this.program.gitPath)) {
 			try {
 				this.gitHash = childProcess
-					.execSync(`cd ${this.program.projectPath} && git rev-parse HEAD`)
-					.toString().trim().slice(0, 8);
+					.execSync(`cd ${this.program.projectPath} && git rev-parse --short HEAD`)
+					.toString().trim();
 			} catch (err) {
 				console.error(err);
 			}

--- a/test/testProcedureWriter.js
+++ b/test/testProcedureWriter.js
@@ -1,0 +1,39 @@
+/* Specify environment to include mocha globals */
+/* eslint-env node, mocha */
+
+'use strict';
+
+const childProcess = require('child_process');
+const path = require('path');
+const assert = require('chai').assert;
+
+const Procedure = require('../app/model/Procedure');
+
+const EvaDocxProcedureWriter = require('../app/writer/procedure/EvaDocxProcedureWriter');
+
+describe('ProcedureWriter', function() {
+	const procedure = new Procedure();
+	const procedureFile = path.join(__dirname, 'cases/simple/procedures/proc.yml');
+
+	const err = procedure.populateFromFile(procedureFile);
+	if (err) {
+		throw new Error(err);
+	}
+
+	// using an EvaDocxProcedureWriter because the abstract ProcedureWriter isn't meant to be used
+	// on its own
+	const procWriter = new EvaDocxProcedureWriter({}, procedure);
+
+	describe('getGitHash', function() {
+
+		it('should get a short SHA for the repo', function() {
+
+			procWriter.program.gitPath = '.git';
+			procWriter.program.projectPath = '.';
+			const currentGitHash = childProcess
+				.execSync('git rev-parse --short HEAD')
+				.toString().trim();
+			assert.equal(procWriter.getGitHash(), currentGitHash);
+		});
+	});
+});


### PR DESCRIPTION
Once again, feel free to outright reject this for bikeshedding. This is me basically just getting into the `pat` dev flow with a small simplification and a new test.

* Streamlines collecting a git SHA using the `--short` flag while being a little looser about making sure `pat` is being run in a git repo
 
Tested by running in projects with and without `.git` folders, running from inside a different project with its own `.git`, from outside and inside projects with and without `.git` folders while passing the `projectPath` to `pat`. All seems to work as expected. If run against a project without a `.git` folder, the user will see a small error on the command line as a result of the `git rev-parse` command failing.