### PR TITLE
Allow multiline steps

### DIFF
--- a/app/model/ConcurrentStep.js
+++ b/app/model/ConcurrentStep.js
@@ -119,7 +119,6 @@ module.exports = class ConcurrentStep {
 			def[actor] = [];
 			for (const step of this.subscenes[actor]) {
 				def[actor].push(step.getDefinition());
-				// def[actor].push({ text: step.text, error: 'this is just a test' });
 			}
 		}
 		if (numActors > 1) {

--- a/app/model/ConcurrentStep.spec.js
+++ b/app/model/ConcurrentStep.spec.js
@@ -3,6 +3,7 @@
 
 'use strict';
 
+const assert = require('chai').assert;
 const expect = require('chai').expect;
 const YAML = require('js-yaml');
 
@@ -56,8 +57,8 @@ describe('ConcurrentStep constructor - Positive Testing', function() {
 			expect(concurrentStep.subscenes.EV1).to.be.an('array');
 			expect(concurrentStep.subscenes.EV1).to.have.all.keys(0);
 
-			expect(concurrentStep.subscenes.EV1[0].text).to.be.a('string');
-			expect(concurrentStep.subscenes.EV1[0].text).to.equal('Go Outside');
+			assert.isArray(concurrentStep.subscenes.EV1[0].text);
+			assert.strictEqual(concurrentStep.subscenes.EV1[0].text[0], 'Go Outside');
 		});
 	});
 
@@ -77,8 +78,8 @@ describe('ConcurrentStep constructor - Positive Testing', function() {
 			expect(concurrentStep.subscenes.EV1).to.be.an('array');
 			expect(concurrentStep.subscenes.EV1).to.have.all.keys(0);
 
-			expect(concurrentStep.subscenes.EV1[0].text).to.be.a('string');
-			expect(concurrentStep.subscenes.EV1[0].text).to.equal('Go Outside');
+			assert.isArray(concurrentStep.subscenes.EV1[0].text);
+			assert.strictEqual(concurrentStep.subscenes.EV1[0].text[0], 'Go Outside');
 		});
 	});
 
@@ -100,17 +101,18 @@ describe('ConcurrentStep constructor - Positive Testing', function() {
 			expect(concurrentStep.subscenes.EV1).to.exist;
 			expect(concurrentStep.subscenes.EV1).to.be.an('array');
 			expect(concurrentStep.subscenes.EV1).to.have.all.keys(0);
-			expect(concurrentStep.subscenes.EV1[0].text).to.be.a('string');
-			expect(concurrentStep.subscenes.EV1[0].text).to.equal('Go Outside');
+			assert.isArray(concurrentStep.subscenes.EV1[0].text);
+			assert.strictEqual(concurrentStep.subscenes.EV1[0].text[0], 'Go Outside');
 
 			// eslint-disable-next-line no-unused-expressions
 			expect(concurrentStep.subscenes.EV2).to.exist;
 			expect(concurrentStep.subscenes.EV2).to.be.an('array');
 			expect(concurrentStep.subscenes.EV2).to.have.all.keys(0, 1);
-			expect(concurrentStep.subscenes.EV2[0].text).to.be.a('string');
-			expect(concurrentStep.subscenes.EV2[0].text).to.equal('Stay Inside');
-			expect(concurrentStep.subscenes.EV2[1].text).to.be.a('string');
-			expect(concurrentStep.subscenes.EV2[1].text).to.equal('Watch EV1');
+
+			assert.isArray(concurrentStep.subscenes.EV2[0].text);
+			assert.strictEqual(concurrentStep.subscenes.EV2[0].text[0], 'Stay Inside');
+			assert.isArray(concurrentStep.subscenes.EV2[1].text);
+			assert.strictEqual(concurrentStep.subscenes.EV2[1].text[0], 'Watch EV1');
 		});
 	});
 
@@ -132,17 +134,17 @@ describe('ConcurrentStep constructor - Positive Testing', function() {
 			expect(concurrentStep.subscenes.EV1).to.exist;
 			expect(concurrentStep.subscenes.EV1).to.be.an('array');
 			expect(concurrentStep.subscenes.EV1).to.have.all.keys(0);
-			expect(concurrentStep.subscenes.EV1[0].text).to.be.a('string');
-			expect(concurrentStep.subscenes.EV1[0].text).to.equal('Go Outside');
+			assert.isArray(concurrentStep.subscenes.EV1[0].text);
+			assert.strictEqual(concurrentStep.subscenes.EV1[0].text[0], 'Go Outside');
 
 			// eslint-disable-next-line no-unused-expressions
 			expect(concurrentStep.subscenes.EV2).to.exist;
 			expect(concurrentStep.subscenes.EV2).to.be.an('array');
 			expect(concurrentStep.subscenes.EV2).to.have.all.keys(0, 1);
-			expect(concurrentStep.subscenes.EV2[0].text).to.be.a('string');
-			expect(concurrentStep.subscenes.EV2[0].text).to.equal('Stay Inside');
-			expect(concurrentStep.subscenes.EV2[1].text).to.be.a('string');
-			expect(concurrentStep.subscenes.EV2[1].text).to.equal('Watch EV1');
+			assert.isArray(concurrentStep.subscenes.EV2[0].text);
+			assert.strictEqual(concurrentStep.subscenes.EV2[0].text[0], 'Stay Inside');
+			assert.isArray(concurrentStep.subscenes.EV2[1].text);
+			assert.strictEqual(concurrentStep.subscenes.EV2[1].text[0], 'Watch EV1');
 		});
 	});
 });

--- a/app/model/Procedure.spec.js
+++ b/app/model/Procedure.spec.js
@@ -3,7 +3,9 @@
 
 'use strict';
 
+const assert = require('chai').assert;
 const expect = require('chai').expect;
+
 const sinon = require('sinon');
 const path = require('path');
 
@@ -37,8 +39,11 @@ describe('Procedure', function() {
 		expect(procedure.tasks[0].concurrentSteps[0].subscenes.EV1).to.be.an('array');
 		expect(procedure.tasks[0].concurrentSteps[0].subscenes.EV1).to.have.all.keys(0);
 
-		expect(procedure.tasks[0].concurrentSteps[0].subscenes.EV1[0].text).to.be.a('string');
-		expect(procedure.tasks[0].concurrentSteps[0].subscenes.EV1[0].text).to.equal('Go Outside');
+		assert.isArray(procedure.tasks[0].concurrentSteps[0].subscenes.EV1[0].text);
+		assert.strictEqual(
+			procedure.tasks[0].concurrentSteps[0].subscenes.EV1[0].text[0],
+			'Go Outside'
+		);
 	};
 
 	const procedureDefinition1 = {

--- a/app/model/Step.js
+++ b/app/model/Step.js
@@ -25,7 +25,7 @@ module.exports = class Step {
 		// FIXME: This can't be in props.strings because the YAML input is "step" not "text", and in
 		// getDefinition() it needs the proper YAML input name. Ultimately probably should change
 		// "step" to "text".
-		this.text = '';
+		this.text = [];
 
 		for (const prop of props.arrays) {
 			this[prop] = [];
@@ -55,8 +55,10 @@ module.exports = class Step {
 		}
 
 		// Currently YAML "step" prop maps to model "text" prop. See comment in constructor.
-		if (this.text) {
-			def.step = this.text;
+		if (this.text.length > 1) {
+			def.step = this.text.slice(); // copy the array
+		} else if (this.text.length === 1) {
+			def.step = this.text[0];
 		}
 
 		if (this.images.length) {
@@ -94,7 +96,7 @@ module.exports = class Step {
 
 		// Check if the step is a simple string
 		if (typeof stepYaml === 'string') {
-			this.text = this.parseStepText(stepYaml);
+			this.text = [this.parseStepText(stepYaml)];
 			return;
 		}
 
@@ -107,7 +109,8 @@ module.exports = class Step {
 
 		// Check for the text
 		if (stepYaml.step) {
-			this.text = this.parseStepText(stepYaml.step);
+			const preStep = arrayHelper.parseArray(stepYaml.step);
+			this.text = preStep.map((text) => this.parseStepText(text));
 		}
 
 		// Check for images

--- a/app/model/Step.spec.js
+++ b/app/model/Step.spec.js
@@ -3,7 +3,9 @@
 
 'use strict';
 
+const assert = require('chai').assert;
 const expect = require('chai').expect;
+
 const YAML = require('js-yaml');
 
 const Step = require('./Step');
@@ -65,11 +67,11 @@ describe('Step constructor - Positive Testing', function() {
 
 			expect(step).to.exist; // eslint-disable-line no-unused-expressions
 
-			expect(step.title).to.be.a('string');
-			expect(step.title).to.equal('Initial Configuration');
+			assert.isString(step.title);
+			assert.strictEqual(step.title, 'Initial Configuration');
 
-			expect(step.text).to.be.a('string');
-			expect(step.text).to.equal('{{CHECK}} All gates closed & hooks locked');
+			assert.isArray(step.text);
+			assert.strictEqual(step.text[0], '{{CHECK}} All gates closed & hooks locked');
 
 			expect(step.images).to.be.a('array');
 			expect(step.images).to.have.all.keys(0);
@@ -105,8 +107,9 @@ describe('Step constructor - Positive Testing', function() {
 			expect(step.substeps).to.be.a('array');
 			expect(step.substeps).to.have.all.keys(0);
 			expect(step.substeps[0]).to.be.a('Object');
-			expect(step.substeps[0].text).to.be.a('string');
-			expect(step.substeps[0].text).to.equal('select page - RF camera.');
+
+			assert.isArray(step.substeps[0].text);
+			assert.strictEqual(step.substeps[0].text[0], 'select page - RF camera.');
 
 		});
 	});
@@ -152,8 +155,8 @@ describe('Step constructor - Positive Testing', function() {
 			expect(step.title).to.be.a('string');
 			expect(step.title).to.equal('Initial Configuration');
 
-			expect(step.text).to.be.a('string');
-			expect(step.text).to.equal('{{CHECK}} All gates closed & hooks locked');
+			assert.isArray(step.text);
+			assert.strictEqual(step.text[0], '{{CHECK}} All gates closed & hooks locked');
 
 			expect(step.images).to.be.a('array');
 			expect(step.images).to.have.all.keys(0, 1);
@@ -202,11 +205,12 @@ describe('Step constructor - Positive Testing', function() {
 			expect(step.substeps).to.be.a('array');
 			expect(step.substeps).to.have.all.keys(0, 1);
 			expect(step.substeps[0]).to.be.a('Object');
-			expect(step.substeps[0].text).to.be.a('string');
-			expect(step.substeps[0].text).to.equal('select page - RF camera.');
-			expect(step.substeps[1]).to.be.a('Object');
-			expect(step.substeps[1].text).to.be.a('string');
-			expect(step.substeps[1].text).to.equal('second substep');
+
+			assert.isArray(step.substeps[0].text);
+			assert.strictEqual(step.substeps[0].text[0], 'select page - RF camera.');
+			assert.isObject(step.substeps[1]);
+			assert.isArray(step.substeps[1].text);
+			assert.strictEqual(step.substeps[1].text[0], 'second substep');
 
 		});
 	});

--- a/app/model/Task.spec.js
+++ b/app/model/Task.spec.js
@@ -4,6 +4,8 @@
 'use strict';
 
 const expect = require('chai').expect;
+const assert = require('chai').assert;
+
 const YAML = require('js-yaml');
 
 const Task = require('./Task');
@@ -52,8 +54,9 @@ describe('Task constructor - Positive Testing', function() {
 			expect(task.concurrentSteps[0].subscenes.EV1).to.be.an('array');
 			expect(task.concurrentSteps[0].subscenes.EV1).to.have.all.keys(0);
 
-			expect(task.concurrentSteps[0].subscenes.EV1[0].text).to.be.a('string');
-			expect(task.concurrentSteps[0].subscenes.EV1[0].text).to.equal('Go Outside');
+			assert.isArray(task.concurrentSteps[0].subscenes.EV1[0].text);
+			assert.strictEqual(task.concurrentSteps[0].subscenes.EV1[0].text[0], 'Go Outside');
+
 		});
 	});
 });

--- a/app/step-mods/ApfrInstall.js
+++ b/app/step-mods/ApfrInstall.js
@@ -78,11 +78,6 @@ module.exports = class ApfrInstall extends StepModule {
 
 	alterStepDocx() {
 
-		// const textRuns = [];
-		// if (this.step.text) {
-		// textRuns.push(...this.transform(this.step.text));
-		// }
-
 		const changes = {
 			body: {
 				content: [],
@@ -103,7 +98,7 @@ module.exports = class ApfrInstall extends StepModule {
 			text: `Install APFR in ${this.wif} `
 		});
 
-		if (this.step.text) {
+		if (this.step.text.length) {
 			// if there is step text, put first APFR text on a new line
 			installAPFR.break();
 		}

--- a/app/step-mods/ApfrInstall.js
+++ b/app/step-mods/ApfrInstall.js
@@ -69,29 +69,26 @@ module.exports = class ApfrInstall extends StepModule {
 
 	alterStepBase() {
 		return {
-			body: {
-				content: [`Install APFR in ${this.wif} [${getSettings(this).join(',')}]`],
-				type: 'APPEND'
-			}
+			body: this.formatStepModAlterations(
+				'APPEND',
+				`Install APFR in ${this.wif} [${getSettings(this).join(',')}]`
+			)
 		};
 	}
 
 	alterStepDocx() {
 
 		const changes = {
-			body: {
-				content: [],
-				type: 'APPEND'
-			},
-			checkboxes: {
+			body: this.formatStepModAlterations('APPEND'),
+			checkboxes: this.formatStepModAlterations(
+				'PREPEND',
 				// push some checkboxes onto the front
-				content: [
+				[
 					'Pull/twist test',
 					'Black-on-black',
 					'pitch knob locked, can be depressed'
-				],
-				type: 'PREPEND'
-			}
+				]
+			)
 		};
 
 		const installAPFR = new docx.TextRun({

--- a/app/step-mods/ApfrInstall.js
+++ b/app/step-mods/ApfrInstall.js
@@ -70,7 +70,7 @@ module.exports = class ApfrInstall extends StepModule {
 	alterStepBase() {
 		return {
 			body: {
-				content: `Install APFR in ${this.wif} [${getSettings(this).join(',')}]`,
+				content: [`Install APFR in ${this.wif} [${getSettings(this).join(',')}]`],
 				type: 'APPEND'
 			}
 		};

--- a/app/step-mods/ApfrInstall.spec.js
+++ b/app/step-mods/ApfrInstall.spec.js
@@ -22,7 +22,7 @@ const goodSettings = [
 			},
 			alterStepBase: {
 				body: {
-					content: 'Install APFR in SSRMS [6,PP,F,6]',
+					content: ['Install APFR in SSRMS [6,PP,F,6]'],
 					type: 'APPEND'
 				}
 			}
@@ -44,7 +44,7 @@ const goodSettings = [
 			},
 			alterStepBase: {
 				body: {
-					content: 'Install APFR in P6 WIF 1 [12,RR,G,11]',
+					content: ['Install APFR in P6 WIF 1 [12,RR,G,11]'],
 					type: 'APPEND'
 				}
 			}

--- a/app/step-mods/PgtSet.js
+++ b/app/step-mods/PgtSet.js
@@ -180,7 +180,7 @@ module.exports = class PgtSet extends StepModule {
 		});
 
 		// if there is step text, put first PGT text on a new line
-		if (this.step.text) {
+		if (this.step.text.length) {
 			setPGT.break();
 		}
 		changes.body.content.push(setPGT);

--- a/app/step-mods/PgtSet.js
+++ b/app/step-mods/PgtSet.js
@@ -151,7 +151,7 @@ module.exports = class PgtSet extends StepModule {
 	alterStepBase() {
 		return {
 			body: {
-				content: `${getSetString(this)} ${getValueString(this)}`,
+				content: [`${getSetString(this)} ${getValueString(this)}`],
 				type: 'APPEND'
 			}
 		};
@@ -160,7 +160,7 @@ module.exports = class PgtSet extends StepModule {
 	alterStepHtml() {
 		return {
 			body: {
-				content: `<strong>${getSetString(this)}</strong><br />${getValueString(this)}`,
+				content: [`<strong>${getSetString(this)}</strong><br />${getValueString(this)}`],
 				type: 'APPEND'
 			}
 		};

--- a/app/step-mods/PgtSet.js
+++ b/app/step-mods/PgtSet.js
@@ -2,8 +2,6 @@
 
 const StepModule = require('./StepModule');
 const docx = require('docx');
-// FIXME const uuidv4 = require('uuid/v4');
-let reactStepModuleFunctions;
 
 const validSettings = {
 	torque: {
@@ -117,7 +115,7 @@ function getMtlAndSocket(mtlOrSocket, socketOrNull = null) {
 module.exports = class PgtSet extends StepModule {
 
 	constructor(step, stepYaml) {
-		super('APPEND');
+		super();
 		this.key = 'pgt.set';
 		this.step = step;
 		this.raw = stepYaml;
@@ -150,28 +148,22 @@ module.exports = class PgtSet extends StepModule {
 
 	alterStepBase() {
 		return {
-			body: {
-				content: [`${getSetString(this)} ${getValueString(this)}`],
-				type: 'APPEND'
-			}
+			body: this.formatStepModAlterations('APPEND', `${getSetString(this)} ${getValueString(this)}`)
 		};
 	}
 
 	alterStepHtml() {
 		return {
-			body: {
-				content: [`<strong>${getSetString(this)}</strong><br />${getValueString(this)}`],
-				type: 'APPEND'
-			}
+			body: this.formatStepModAlterations(
+				'APPEND',
+				`<strong>${getSetString(this)}</strong><br />${getValueString(this)}`
+			)
 		};
 	}
 
 	alterStepDocx() {
 		const changes = {
-			body: {
-				content: [],
-				type: 'APPEND'
-			}
+			body: this.formatStepModAlterations('APPEND')
 		};
 
 		const setPGT = new docx.TextRun({
@@ -195,14 +187,7 @@ module.exports = class PgtSet extends StepModule {
 	}
 
 	alterStepReact() {
-		if (!reactStepModuleFunctions) {
-			reactStepModuleFunctions = require('./PgtSetReact');
-		}
-		if (!this.doAlterStepReact) {
-			this.doAlterStepReact = reactStepModuleFunctions.doAlterStepReact;
-			PgtSet.prototype.doAlterStepReact = reactStepModuleFunctions.doAlterStepReact;
-		}
-
+		this.setupAlterStepReact();
 		return this.doAlterStepReact(getSetString, getValueString);
 	}
 

--- a/app/step-mods/PgtSet.js
+++ b/app/step-mods/PgtSet.js
@@ -168,29 +168,26 @@ module.exports = class PgtSet extends StepModule {
 	}
 
 	alterStepDocx() {
-		const changes = {
-			body: this.formatStepModAlterations('APPEND')
-		};
 
 		const setPGT = new docx.TextRun({
 			text: getSetString(this),
 			bold: true
 		});
 
-		// if there is step text, put first PGT text on a new line
-		// if (this.step.text.length) {
-		// 	setPGT.break();
-		// }
-		changes.body.content.push(setPGT);
+		// Previously had to do this to separate initial pgt.set text from ordinary step.text, but
+		// now TaskWriter handles putting newlines between all step body elements. See each
+		// (FormatType)TaskWriter.addStepText(). Also no longer have to explicitly add a break
+		// between setPgt and pgtValues TextRuns.
+		// if (this.step.text.length) { setPGT.break(); }
 
-		changes.body.content.push(
-			new docx.TextRun({
-				text: getValueString(this)
-			})
-			// .break() no longer required because now all lines in content have breaks between them
-		);
+		const pgtValues = new docx.TextRun({
+			text: getValueString(this)
+		});
 
-		return changes;
+		return {
+			body: this.formatStepModAlterations('APPEND', [setPGT, pgtValues])
+		};
+
 	}
 
 	alterStepReact() {

--- a/app/step-mods/PgtSet.js
+++ b/app/step-mods/PgtSet.js
@@ -148,7 +148,10 @@ module.exports = class PgtSet extends StepModule {
 
 	alterStepBase() {
 		return {
-			body: this.formatStepModAlterations('APPEND', `${getSetString(this)} ${getValueString(this)}`)
+			body: this.formatStepModAlterations(
+				'APPEND',
+				`${getSetString(this)} ${getValueString(this)}`
+			)
 		};
 	}
 
@@ -156,7 +159,10 @@ module.exports = class PgtSet extends StepModule {
 		return {
 			body: this.formatStepModAlterations(
 				'APPEND',
-				`<strong>${getSetString(this)}</strong><br />${getValueString(this)}`
+				[
+					`<strong>${getSetString(this)}</strong>`,
+					getValueString(this)
+				]
 			)
 		};
 	}
@@ -172,15 +178,16 @@ module.exports = class PgtSet extends StepModule {
 		});
 
 		// if there is step text, put first PGT text on a new line
-		if (this.step.text.length) {
-			setPGT.break();
-		}
+		// if (this.step.text.length) {
+		// 	setPGT.break();
+		// }
 		changes.body.content.push(setPGT);
 
 		changes.body.content.push(
 			new docx.TextRun({
 				text: getValueString(this)
-			}).break()
+			})
+			// .break() no longer required because now all lines in content have breaks between them
 		);
 
 		return changes;

--- a/app/step-mods/PgtSet.spec.js
+++ b/app/step-mods/PgtSet.spec.js
@@ -19,7 +19,7 @@ const goodSettings = [
 			},
 			alterStepBase: {
 				body: {
-					content: 'PGT [B7, CCW2] (25.5 ft-lb, 30 RPM, MTL 30.5)',
+					content: ['PGT [B7, CCW2] (25.5 ft-lb, 30 RPM, MTL 30.5)'],
 					type: 'APPEND'
 				}
 			}
@@ -37,7 +37,7 @@ const goodSettings = [
 			},
 			alterStepBase: {
 				body: {
-					content: 'PGT [B1, CCW1] (12.0 ft-lb, 10 RPM, MTL 30.5) - 6" Wobble',
+					content: ['PGT [B1, CCW1] (12.0 ft-lb, 10 RPM, MTL 30.5) - 6" Wobble'],
 					type: 'APPEND'
 				}
 			}
@@ -55,7 +55,7 @@ const goodSettings = [
 			},
 			alterStepBase: {
 				body: {
-					content: 'PGT [A7, CW2, 30.5] (9.2 ft-lb, 30 RPM, MTL 30.5)',
+					content: ['PGT [A7, CW2, 30.5] (9.2 ft-lb, 30 RPM, MTL 30.5)'],
 					type: 'APPEND'
 				}
 			}
@@ -73,7 +73,7 @@ const goodSettings = [
 			},
 			alterStepBase: {
 				body: {
-					content: 'PGT [B1, CW1, 2.5] (12.0 ft-lb, 10 RPM, MTL 2.5)',
+					content: ['PGT [B1, CW1, 2.5] (12.0 ft-lb, 10 RPM, MTL 2.5)'],
 					type: 'APPEND'
 				}
 			}
@@ -91,7 +91,7 @@ const goodSettings = [
 			},
 			alterStepBase: {
 				body: {
-					content: 'PGT [B7, CW2, 2.5] (25.5 ft-lb, 30 RPM, MTL 2.5) - 7/16 x 18" Wobble Socket',
+					content: ['PGT [B7, CW2, 2.5] (25.5 ft-lb, 30 RPM, MTL 2.5) - 7/16 x 18" Wobble Socket'],
 					type: 'APPEND'
 				}
 			}
@@ -110,7 +110,7 @@ const goodSettings = [
 			},
 			alterStepBase: {
 				body: {
-					content: 'PGT [B7, CW2] (25.5 ft-lb, 30 RPM, MTL 30.5)',
+					content: ['PGT [B7, CW2] (25.5 ft-lb, 30 RPM, MTL 30.5)'],
 					type: 'APPEND'
 				}
 			}

--- a/app/step-mods/PgtSetReact.js
+++ b/app/step-mods/PgtSetReact.js
@@ -18,19 +18,12 @@ module.exports = {
 
 		const setText = (
 			<React.Fragment key={uuidv4()}>
-				{
-					// Note: if there is step text, put first PGT text on a new line
-					this.step.text.length ?
-						this.step.text.map((text) => (<p key={uuidv4()}>{text}</p>)) :
-						null
-				}
 				<strong>{getSetString(this)}</strong>
 			</React.Fragment>
 		);
 
 		const valuesText = (
 			<React.Fragment key={uuidv4()}>
-				<br />
 				<span>{getValueString(this)}</span>
 			</React.Fragment>
 		);

--- a/app/step-mods/PgtSetReact.js
+++ b/app/step-mods/PgtSetReact.js
@@ -4,53 +4,40 @@ const React = require('react');
 const uuidv4 = require('uuid/v4');
 
 module.exports = {
+	/**
+	 * Function bolted onto PgtSet class to handle React elements
+	 *
+	 * @param {Function} getSetString    Function from PgtSet.js
+	 * @param {Function} getValueString  Function from PgtSet.js
+	 * @return {Object}                  Changes object in form from
+	 *                                   StepModule.formatStepModAlterations()
+	 *
+	 * @this PgtSet
+	 */
 	doAlterStepReact: function(getSetString, getValueString) {
 
-		const changes = {
-			body: {
-				content: [],
-				type: 'APPEND'
-			}
+		const setText = (
+			<React.Fragment key={uuidv4()}>
+				{
+					// Note: if there is step text, put first PGT text on a new line
+					this.step.text.length ?
+						this.step.text.map((text) => (<p key={uuidv4()}>{text}</p>)) :
+						null
+				}
+				<strong>{getSetString(this)}</strong>
+			</React.Fragment>
+		);
+
+		const valuesText = (
+			<React.Fragment key={uuidv4()}>
+				<br />
+				<span>{getValueString(this)}</span>
+			</React.Fragment>
+		);
+
+		return {
+			body: this.formatStepModAlterations('APPEND', [setText, valuesText])
 		};
-
-		// ! FIXME this shouldn't need to be here anymore. Handle higher up
-		// if (this.step.text) {
-		// if (typeof this.step.text === 'string') {
-		// children.push(...this.transform(this.step.text));
-		// } else if (Array.isArray(this.step.text)) {
-		// for (let thing of this.step.text) {
-		// thing = this.transform(thing);
-		// }
-		// } else if (typeof this.step.text === 'object'
-		// && true /* FIXME: replace true with real check for react component */) {
-		// children.push(this.step.text); // FIXME: make sure has key?
-		// }
-		// }
-
-		// Note: if there is step text, put first PGT text on a new line
-		changes.body.content.push(
-			(
-				<React.Fragment key={uuidv4()}>
-					{
-						this.step.text.length ?
-							this.step.text.map((text) => (<p key={uuidv4()}>{text}</p>)) :
-							null
-					}
-					<strong>{getSetString(this)}</strong>
-				</React.Fragment>
-			)
-		);
-
-		changes.body.content.push(
-			(
-				<React.Fragment key={uuidv4()}>
-					<br />
-					<span>{getValueString(this)}</span>
-				</React.Fragment>
-			)
-		);
-
-		return changes;
 	}
 
 };

--- a/app/step-mods/PgtSetReact.js
+++ b/app/step-mods/PgtSetReact.js
@@ -16,20 +16,18 @@ module.exports = {
 	 */
 	doAlterStepReact: function(getSetString, getValueString) {
 
-		const setText = (
-			<React.Fragment key={uuidv4()}>
-				<strong>{getSetString(this)}</strong>
-			</React.Fragment>
-		);
-
-		const valuesText = (
-			<React.Fragment key={uuidv4()}>
-				<span>{getValueString(this)}</span>
-			</React.Fragment>
-		);
-
 		return {
-			body: this.formatStepModAlterations('APPEND', [setText, valuesText])
+			body: this.formatStepModAlterations(
+				'APPEND',
+				(
+					<React.Fragment key={uuidv4()}>
+						<strong>{getSetString(this)}</strong>
+						<br />
+						<span>{getValueString(this)}</span>
+					</React.Fragment>
+				)
+			)
+
 		};
 	}
 

--- a/app/step-mods/PgtSetReact.js
+++ b/app/step-mods/PgtSetReact.js
@@ -31,7 +31,11 @@ module.exports = {
 		changes.body.content.push(
 			(
 				<React.Fragment key={uuidv4()}>
-					{ this.step.text ? <br /> : null }
+					{
+						this.step.text.length ?
+							this.step.text.map((text) => (<p key={uuidv4()}>{text}</p>)) :
+							null
+					}
 					<strong>{getSetString(this)}</strong>
 				</React.Fragment>
 			)

--- a/app/writer/task/DocxTaskWriter.js
+++ b/app/writer/task/DocxTaskWriter.js
@@ -317,7 +317,7 @@ module.exports = class DocxTaskWriter extends TaskWriter {
 				if (typeof elem === 'string') {
 					elem = this.textTransform.transform(elem);
 				} else if (!Array.isArray(elem)) {
-					console.log('This should not happen'); // FIXME
+					// elem is a TextRun object
 					elem = [elem];
 				}
 

--- a/app/writer/task/DocxTaskWriter.js
+++ b/app/writer/task/DocxTaskWriter.js
@@ -317,7 +317,14 @@ module.exports = class DocxTaskWriter extends TaskWriter {
 				if (typeof elem === 'string') {
 					elem = this.textTransform.transform(elem);
 				} else if (!Array.isArray(elem)) {
+					console.log('This should not happen'); // FIXME
 					elem = [elem];
+				}
+
+				// if there is more than one line of step text, make all but the first have a line
+				// break in front
+				if (s > 0) {
+					elem[0].break();
 				}
 				paraOptions.children.push(...elem);
 			}

--- a/app/writer/task/HtmlTaskWriter.js
+++ b/app/writer/task/HtmlTaskWriter.js
@@ -115,8 +115,6 @@ module.exports = class HtmlTaskWriter extends TaskWriter {
 				if (typeof elem === 'string') {
 					elem = this.textTransform.transform(elem);
 				} else if (!Array.isArray(elem)) {
-					console.log('This should not happen'); // FIXME
-					console.log(elem);
 					throw new Error('Expect string or array');
 				}
 

--- a/app/writer/task/HtmlTaskWriter.js
+++ b/app/writer/task/HtmlTaskWriter.js
@@ -116,11 +116,13 @@ module.exports = class HtmlTaskWriter extends TaskWriter {
 					elem = this.textTransform.transform(elem);
 				} else if (!Array.isArray(elem)) {
 					console.log('This should not happen'); // FIXME
+					console.log(elem);
 					throw new Error('Expect string or array');
 				}
 
 				// if there is more than one line, separate them with break
 				if (s > 0) {
+					console.log(stepText);
 					texts.push('<br />');
 				}
 

--- a/app/writer/task/HtmlTaskWriter.js
+++ b/app/writer/task/HtmlTaskWriter.js
@@ -115,8 +115,15 @@ module.exports = class HtmlTaskWriter extends TaskWriter {
 				if (typeof elem === 'string') {
 					elem = this.textTransform.transform(elem);
 				} else if (!Array.isArray(elem)) {
+					console.log('This should not happen'); // FIXME
 					throw new Error('Expect string or array');
 				}
+
+				// if there is more than one line, separate them with break
+				if (s > 0) {
+					texts.push('<br />');
+				}
+
 				texts.push(...elem);
 			}
 		} else {

--- a/app/writer/task/HtmlTaskWriter.js
+++ b/app/writer/task/HtmlTaskWriter.js
@@ -120,7 +120,6 @@ module.exports = class HtmlTaskWriter extends TaskWriter {
 
 				// if there is more than one line, separate them with break
 				if (s > 0) {
-					console.log(stepText);
 					texts.push('<br />');
 				}
 
@@ -129,12 +128,6 @@ module.exports = class HtmlTaskWriter extends TaskWriter {
 		} else {
 			throw new Error('addStepText() stepText must be string or array');
 		}
-
-		// FIXMEFIXMEFIXME
-		// console.log('\n\n');
-		// console.log(texts);
-		// const transformed = texts.join('');
-		// console.log(transformed);
 
 		// added class li-level-${options.level} really just as a way to remind that
 		// some handling of this will be necessary

--- a/app/writer/task/ReactTaskWriter.js
+++ b/app/writer/task/ReactTaskWriter.js
@@ -224,6 +224,8 @@ module.exports = class ReactTaskWriter extends TaskWriter {
 				let elem = stepText[s];
 				if (typeof elem === 'string') {
 					elem = this.textTransform.transform(elem);
+				} else {
+					console.log(elem);
 				}
 				// else { assume it's a react object }
 
@@ -240,7 +242,7 @@ module.exports = class ReactTaskWriter extends TaskWriter {
 					(<strong>{actorText}: </strong>) :
 					(<React.Fragment></React.Fragment>)
 				}
-				{stepTextComponent}
+				{stepTextComponent.map((t) => (<p key={uuidv4()}>{t}</p>))}
 			</div>
 		);
 	}

--- a/app/writer/task/TaskWriter.js
+++ b/app/writer/task/TaskWriter.js
@@ -175,9 +175,9 @@ module.exports = class TaskWriter extends Abstract {
 			elements.prebody.push(this.addBlock('comment', step.comments));
 		}
 
-		if (step.text) {
+		if (step.text.length) {
 			// todo: could make text optionally an array to do newlines
-			elements.body.push(step.text);
+			elements.body.push(...step.text);
 		}
 
 		if (step.checkboxes.length) {


### PR DESCRIPTION
This PR changes Maestro from just allowing this structure:

```yaml
- step: Tighten bolts (ten) in X pattern; Repeat until all bolts are snug
```

And additionally allows:

```yaml
- step:
   - Tighten bolts (ten) in X pattern
   - Repeat until all bolts are snug
```

The former displays like this:
![image](https://user-images.githubusercontent.com/716482/72572308-bebcb500-3887-11ea-8c28-535ef1a23846.png)

Whereas the latter displays like this:
![image](https://user-images.githubusercontent.com/716482/72572338-d98f2980-3887-11ea-807a-62a7538bd697.png)

Closes #101 

This is WIP until tests are updated accordingly and pass