### PR TITLE
Also allow step.text in addition to legacy step.step in YAML

### DIFF
--- a/app/model/Step.js
+++ b/app/model/Step.js
@@ -56,9 +56,9 @@ module.exports = class Step {
 
 		// Currently YAML "step" prop maps to model "text" prop. See comment in constructor.
 		if (this.text.length > 1) {
-			def.step = this.text.slice(); // copy the array
+			def.text = this.text.slice(); // copy the array
 		} else if (this.text.length === 1) {
-			def.step = this.text[0];
+			def.text = this.text[0];
 		}
 
 		if (this.images.length) {
@@ -90,6 +90,20 @@ module.exports = class Step {
 		return def;
 	}
 
+	getTextFromDefinition(stepYaml) {
+		if (stepYaml.step || stepYaml.text) {
+			if (stepYaml.step && stepYaml.text) {
+				throw new Error(
+					'The "step" property is deprecated, and "text" is preferred, but both cannot be set'
+				);
+			}
+			const content = stepYaml.text ? stepYaml.text : stepYaml.step;
+			const preStep = arrayHelper.parseArray(content);
+			return preStep.map((text) => this.parseStepText(text));
+		}
+		return [];
+	}
+
 	populateFromYaml(stepYaml) {
 
 		this.raw = stepYaml;
@@ -108,10 +122,7 @@ module.exports = class Step {
 		}
 
 		// Check for the text
-		if (stepYaml.step) {
-			const preStep = arrayHelper.parseArray(stepYaml.step);
-			this.text = preStep.map((text) => this.parseStepText(text));
-		}
+		this.text = this.getTextFromDefinition(stepYaml);
 
 		// Check for images
 		if (stepYaml.images) {

--- a/app/model/Step.spec.js
+++ b/app/model/Step.spec.js
@@ -214,4 +214,45 @@ describe('Step constructor - Positive Testing', function() {
 
 		});
 	});
+
+	describe('getTextFromDefinition()', function() {
+		const step = new Step({ warning: 'dummy step' }, 'EV1', taskRoles);
+		const goodTestCases = [
+			{
+				input: { step: 'using step key' },
+				expected: ['using step key']
+			},
+			{
+				input: { text: 'using text key' },
+				expected: ['using text key']
+			},
+			{
+				input: { neither: 'no .text or .step' },
+				expected: []
+			}
+		];
+
+		const erroringTestCases = [
+			{ step: 'has .step ...', text: '... and .text' }
+		];
+
+		for (const testCase of goodTestCases) {
+			it(`should return ${JSON.stringify(testCase.expected)} for input ${JSON.stringify(testCase.input)}`, function() {
+				assert.deepStrictEqual(
+					step.getTextFromDefinition(testCase.input),
+					testCase.expected
+				);
+			});
+		}
+
+		for (const testCase of erroringTestCases) {
+			it(`should throw error for ${JSON.stringify(testCase)}`, function() {
+				assert.throws(function() {
+					step.getTextFromDefinition(testCase.input);
+				});
+			});
+
+		}
+	});
+
 });


### PR DESCRIPTION
Previously had to do this:

```yaml
- title: EGRESS/SETUP
  duration:
    minutes: 25
  step: Attach EV1 ANCHOR hook to fwd external D-ring
  checkboxes:
    - '{{CHECK}}Gate closed'
    - '{{CHECK}}Hook locked'
```

This whole block of YAML is a step. A step can include `title`, `duration`, `checkboxes`, etc. The most commonly used is `step`, which really means `text` since, again, the whole block is a step and the text is just part of it. This PR allows either the format above, or:

```yaml
- title: EGRESS/SETUP
  duration:
    minutes: 25
  text: Attach EV1 ANCHOR hook to fwd external D-ring
  checkboxes:
    - '{{CHECK}}Gate closed'
    - '{{CHECK}}Hook locked'
```

Note that here `step` is replaced with `text`. Either is valid now. Maestro web editor will convert to `text`. A block of simple steps now can look like:

```yaml
- text: 'On EV1 GO, release Waist Tether from A/L D-ring Extender'
- text: Transfer Medium ORU Bag to EV1
- text: Transfer Thing to EV1; keep RET (Lg-sm) with Thing
- text: 'On EV1 GO, egress A/L'
- text: Receive Thing from EV1; stow on BRT
- text: 'Perform buddy checks'
```

This (a) makes more sense, and (b) makes the YAML more accurately reflect how the `Step` object represents it internally. The `Step` object does not have a `Step.step` but a `Step.text`.