### PR TITLE
Add ability to render PNGs from SVGs in browser (specifically timeline)

### DIFF
--- a/app/web/mocks/svg2img.js
+++ b/app/web/mocks/svg2img.js
@@ -1,0 +1,38 @@
+'use strict';
+
+/**
+ * Callback for adding two numbers.
+ *
+ * @callback imageDataReadyCallback
+ * @param {boolean|Object} error - Error or false (currently no error handling)
+ * @param {string} imageDataUrl - Base64 image data to be inserted into <img src="<here>" /> or
+ *                                otherwise handled.
+ */
+
+/**
+ *
+ * @param {string} svgAsXML - XML string representation of the SVG
+ * @param {Object} dimensions - Like { width: 900, height: 500 }
+ * @param {imageDataReadyCallback} callback - Function to call when image data is ready
+ */
+function browserNativeSvgToImg(svgAsXML, dimensions, callback) {
+
+	const can = document.createElement('canvas'); // Not shown on page
+	const ctx = can.getContext('2d');
+
+	const loader = new Image(); // Not shown on page
+	loader.width = can.width = dimensions.width;
+	loader.height = can.height = dimensions.height;
+
+	loader.onload = function() {
+		ctx.drawImage(loader, 0, 0, loader.width, loader.height);
+		callback(
+			false, // no error. this arg is required to match svg2img interface.
+			can.toDataURL()
+		);
+	};
+
+	loader.src = 'data:image/svg+xml,' + encodeURIComponent(svgAsXML);
+}
+
+module.exports = browserNativeSvgToImg;

--- a/app/web/mocks/svgdom.js
+++ b/app/web/mocks/svgdom.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+
+};

--- a/app/writer/timeline/SvgTimelineWriter.js
+++ b/app/writer/timeline/SvgTimelineWriter.js
@@ -2,6 +2,7 @@
 
 const fs = require('fs');
 const svg2img = require('svg2img');
+const envHelper = require('../../helpers/envHelper');
 const objectHelper = require('../../helpers/objectHelper');
 const TimelineWriter = require('./TimelineWriter');
 
@@ -231,21 +232,30 @@ module.exports = class SvgTimelineWriter extends TimelineWriter {
 	 */
 	create() {
 
-		// svgdom returns 'new Window()'. We don't want to get a reference to the same Window object
-		// on all uses. We want a new window each time. Get the Window constructor and construct our
-		// own new Window.
-		const WindowConstructor = require('svgdom').constructor;
-		const window = new WindowConstructor();
+		// If in a browser context (electron or other) use native window object
+		if (typeof window !== 'undefined' && window.isElectron || envHelper.isBrowser) {
 
-		// When SVG timeline extends generic timeline, move this to top of file
-		const document = window.document;
-		const { SVG, registerWindow } = require('@svgdotjs/svg.js');
+			const { SVG } = require('@svgdotjs/svg.js');
+			this.canvas = SVG().size(this.imageWidth, this.imageHeight);
 
-		// register window and document
-		registerWindow(window, document);
+		// In Node context, fabricate a window object
+		} else {
+			// svgdom returns 'new Window()'. We don't want to get a reference to the same Window
+			// object on all uses. We want a new window each time. Get the Window constructor and
+			// construct our own new Window.
+			const WindowConstructor = require('svgdom').constructor;
+			const window = new WindowConstructor();
 
-		// create canvas
-		this.canvas = SVG(document.documentElement).size(this.imageWidth, this.imageHeight);
+			// When SVG timeline extends generic timeline, move this to top of file
+			const document = window.document;
+			const { SVG, registerWindow } = require('@svgdotjs/svg.js');
+
+			// register window and document
+			registerWindow(window, document);
+
+			// create canvas
+			this.canvas = SVG().size(this.imageWidth, this.imageHeight);
+		}
 
 		// Create the underlying lines and text for the timeline (not tasks themselves)
 		addTimelineMarkings(this);
@@ -284,7 +294,16 @@ module.exports = class SvgTimelineWriter extends TimelineWriter {
 				if (error) {
 					throw error;
 				}
-				fs.writeFileSync(filename, buffer);
+				const isBase64 = typeof buffer.indexOf === 'function' &&
+					buffer.indexOf('data:image/png;base64,') !== -1;
+
+				if (isBase64) {
+					buffer = buffer.replace(/^data:image\/png;base64,/, '');
+				}
+
+				const options = isBase64 ? { encoding: 'base64' } : undefined;
+
+				fs.writeFileSync(filename, buffer, options);
 				callback(dimensions);
 			}
 		);

--- a/webpack/config-electron.js
+++ b/webpack/config-electron.js
@@ -1,5 +1,5 @@
 const path = require('path');
-// const webpack = require('webpack');
+const webpack = require('webpack');
 
 // common config between web and electron
 const moduleRules = require('./common/module-rules');
@@ -26,7 +26,17 @@ module.exports = {
 
 	// Electron does not need to supply the mocks for things like fs, child_process, etc, since it
 	// has the full Node.js API.
-	plugins: [],
+	// But it doesn't need the node canvas element
+	plugins: [
+		new webpack.NormalModuleReplacementPlugin(
+			/^svg2img$/,
+			path.resolve(__dirname, '../app/web/mocks/svg2img.js')
+		),
+		new webpack.NormalModuleReplacementPlugin(
+			/^svgdom$/,
+			path.resolve(__dirname, '../app/web/mocks/svgdom.js')
+		)
+	],
 
 	context: configContext,
 	module: { rules: moduleRules }

--- a/webpack/config-web.js
+++ b/webpack/config-web.js
@@ -36,6 +36,14 @@ module.exports = {
 			path.resolve(__dirname, '../app/web/mocks/child_process.js')
 		),
 		new webpack.NormalModuleReplacementPlugin(
+			/^svg2img$/,
+			path.resolve(__dirname, '../app/web/mocks/svg2img.js')
+		),
+		new webpack.NormalModuleReplacementPlugin(
+			/^svgdom$/,
+			path.resolve(__dirname, '../app/web/mocks/svgdom.js')
+		),
+		new webpack.NormalModuleReplacementPlugin(
 			/^.*\/envHelper$/,
 			path.resolve(__dirname, '../app/web/mocks/envHelper.js')
 		),


### PR DESCRIPTION
Two packages have to be removed by Webpack to run SVG conversion in
browser: svg2img and svgdom. Both of these have conflicts with the
browser (node native canvas versus browser canvas and mockup of a window
object versus an actual browser window object). In the case of svgdom,
just remove the unneeded module (replace with empty object). In the case
of svg2img, use a browser-friendly function instead.

While this work was predominantly done to make it possible to render
summary timelines from SVGs into PNGs in the browser, this will likely
have future usefulness in importing images in the editor UI, and perhaps
annotating them.