### PR TITLE
Fix issue where commit msg file doesn't get cleaned up

### DIFF
--- a/app/electron/renderer.js
+++ b/app/electron/renderer.js
@@ -182,6 +182,7 @@ window.maestro.gitCommit = function(summary, description = '') {
 			});
 			output.push(result);
 		} catch (error) {
+			fs.unlinkSync(commitMsgFile); // FIXME this should be a temp file not in project repo
 			console.error(error);
 			return { error, output };
 		}


### PR DESCRIPTION
If something interupted a git operation, then the commit message file generated initially would not get cleaned up. This could also be fixed by putting `.commitmsg` in a temp directory rather than a Maestro project directory.