### PR TITLE
Fix indexer ordering on step drag

### DIFF
--- a/app/web/components/layout/SeriesComponent.js
+++ b/app/web/components/layout/SeriesComponent.js
@@ -144,7 +144,8 @@ class SeriesComponent extends React.Component {
 		// attached to the bottom of the SeriesComponent, there will not be a stepIndex. Instead it
 		// will explicitly define the stepIndex as false. Set it to the end of the Series.
 		if (to.stepIndex === false) {
-			to.stepIndex = destinationSeries.steps.length;
+			// Insert location, ref issue #142
+			to.stepIndex = destinationSeries.steps.length - 1;
 		}
 
 		this.props.seriesState.transferStep(from.stepIndex, destinationSeries, to.stepIndex);


### PR DESCRIPTION
Doing `maestro.app.procedure.indexer.after(someUuid)` was showing that the order maintained by the indexer wasn't being updated when steps dragged between series. This PR fixes that. Working towards #130 but have not solved it yet.