### PR TITLE
Fix comment block colors

### DIFF
--- a/app/assets/css/base-eva.css
+++ b/app/assets/css/base-eva.css
@@ -108,6 +108,11 @@ p {
 	color: black;
 }
 
+.ncw-comment .ncw-head {
+	background-color: green;
+	color: white;
+}
+
 .ncw-body {
 	padding: 5px;
 }

--- a/app/assets/css/static-eva.css
+++ b/app/assets/css/static-eva.css
@@ -98,6 +98,11 @@ li p {
 	color: black;
 }
 
+.ncw-comment .ncw-head {
+	background-color: green;
+	color: white;
+}
+
 .ncw-body {
 	padding: 5px;
 }

--- a/app/writer/task/DocxTaskWriter.js
+++ b/app/writer/task/DocxTaskWriter.js
@@ -73,14 +73,14 @@ module.exports = class DocxTaskWriter extends TaskWriter {
 		const numbering = this.taskNumbering;
 
 		const fillColors = {
-			comment: '00FF00',
+			comment: '008000',
 			note: 'FFFFFF',
 			caution: 'FFFF00',
 			warning: 'FF0000'
 		};
 
 		const textColors = {
-			comment: '000000',
+			comment: 'FFFFFF',
 			note: '000000',
 			caution: '000000',
 			warning: 'FFFFFF'


### PR DESCRIPTION
In React, comment blocks were white (not the green they're supposed to be)

In DOCX, comments were an ugly green.

This PR makes them consistent.