### PR TITLE
Allow swapping roles without reloading editor

### DIFF
--- a/app/web/components/layout/ActivityMetaForm.js
+++ b/app/web/components/layout/ActivityMetaForm.js
@@ -123,6 +123,13 @@ const ActivityMetaForm = ({ task }) => {
 
 			task.setState(values);
 
+			// FIXME this is a hack to make sure the Task is updated appropriately. Without this,
+			// when roles are changed, those change the context that in which the task is executed,
+			// and the steps that belong to one role need to be swapped to the other. Forcing a
+			// state update here makes sure those changes appear. But this is ugly. Also there may
+			// be issues with setState firing off multiple subscription notifications.
+			task.setState(task.getTaskDefinition());
+
 			stateHandler.saveChange(
 				stateHandler.state.procedure.TasksHandler.getTaskIndexByUuid(task.uuid)
 			);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maestro",
-  "version": "5.0.0-alpha",
+  "version": "5.1.0-alpha",
   "description": "Composing procedures for space operations",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
When doing this:

![swap-roles mp4-20200304114411](https://user-images.githubusercontent.com/716482/75907193-85c3aa00-5e0d-11ea-9513-f580491d7618.gif)

Previously you had to refresh (ctrl-shift-R) and reopen the procedure before seeing that steps switched columns. This PR fixes that.