### PR TITLE
Bump version to 5.2.2 to test github action

### DIFF
--- a/.github/workflows/electron.yml
+++ b/.github/workflows/electron.yml
@@ -40,21 +40,6 @@ jobs:
           echo ::set-output name=version::$pkgver
         shell: bash # Don't use powershell
 
-      # Save the current package.json's version value
-      # as the output from this step so that we can
-      # reference it later on.
-      - name: Get package-lock version
-        id: pkglock
-        run: |
-          pkgver=$(node ./.github/scripts/get-pkg-version.js)
-          echo ::set-output name=version::$pkgver
-        shell: bash # Don't use powershell
-
-      - name: Ensure package-lock.json version matches package.json version (run npm install)
-        if: steps.pkg.outputs.version != steps.pkglock.outputs.version
-        run: exit 1
-        shell: bash
-
       # Note: Add --vs2015 to install 2015 tools instead of 2017
       - name: Install node windows-build-tools
         if: matrix.os == 'windows-2016'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,11 +42,12 @@ jobs:
           echo ::set-output name=version::$pkgver
         shell: bash # Don't use powershell
 
-      - name: Report versions
-        run: "echo \"package.json: ${{ steps.pkg.outputs.version }}, package-lock.json: ${{ steps.pkglock.outputs.version }}\""
-
       - name: Ensure package-lock.json version matches package.json version (run npm install)
-        if: steps.pkg.outputs.version != steps.pkglock.outputs.version
-        run: exit 1
+        run: |
+          if [${{ steps.pkg.outputs.version }} -eq ${{ steps.pkglock.outputs.version }}]; then
+            exit 0
+          else
+            exit 1
+          fi
         shell: bash
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Get package-lock version
         id: pkglock
         run: |
-          pkgver=$(node ./.github/scripts/get-pkg-version.js)
+          pkgver=$(node ./.github/scripts/get-pkg-version.js --lock)
           echo ::set-output name=version::$pkgver
         shell: bash # Don't use powershell
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,7 @@
-name: Test
-on: [push]
+name: Publish branch pre-merge
+on:
+  push:
+    branches: [publish]
 
 jobs:
 
@@ -39,6 +41,9 @@ jobs:
           pkgver=$(node ./.github/scripts/get-pkg-version.js)
           echo ::set-output name=version::$pkgver
         shell: bash # Don't use powershell
+
+      - name: Report versions
+        run: "echo \"package.json: ${{ steps.pkg.outputs.version }}, package-lock.json: ${{ steps.pkglock.outputs.version }}\""
 
       - name: Ensure package-lock.json version matches package.json version (run npm install)
         if: steps.pkg.outputs.version != steps.pkglock.outputs.version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,47 @@
+name: Test
+on: [push]
+
+jobs:
+
+  # This job just makes sure that the Maestro version in package-lock.json matches the one in
+  # package.json
+  package_lock_updated:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT"
+
+      - uses: actions/checkout@master
+
+      - name: Setup NodeJS 12.x
+        uses: actions/setup-node@master
+        with:
+          node-version: 12.x
+
+      # Save the current package.json's version value
+      # as the output from this step so that we can
+      # reference it later on.
+      - name: Get package version
+        id: pkg
+        run: |
+          pkgver=$(node ./.github/scripts/get-pkg-version.js)
+          echo ::set-output name=version::$pkgver
+        shell: bash # Don't use powershell
+
+      # Save the current package.json's version value
+      # as the output from this step so that we can
+      # reference it later on.
+      - name: Get package-lock version
+        id: pkglock
+        run: |
+          pkgver=$(node ./.github/scripts/get-pkg-version.js)
+          echo ::set-output name=version::$pkgver
+        shell: bash # Don't use powershell
+
+      - name: Ensure package-lock.json version matches package.json version (run npm install)
+        if: steps.pkg.outputs.version != steps.pkglock.outputs.version
+        run: exit 1
+        shell: bash
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Ensure package-lock.json version matches package.json version (run npm install)
         run: |
-          if [${{ steps.pkg.outputs.version }} -eq ${{ steps.pkglock.outputs.version }}]; then
+          if [ "${{ steps.pkg.outputs.version }}" = "${{ steps.pkglock.outputs.version }}" ]; then
             exit 0
           else
             exit 1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "maestro",
-  "version": "5.2.1-alpha",
+  "version": "5.2.2-alpha",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maestro",
-  "version": "5.2.1-alpha",
+  "version": "5.2.2-alpha",
   "description": "Composing procedures for space operations",
   "main": "./app/electron/main.js",
   "scripts": {


### PR DESCRIPTION
The electron build action should create a new release, build a new Windows installer (and someday other platforms), and add builds to the release anytime a pull request from the `publish` branch is merged. Thus, nothing should be seen in this pull request initially, but after it's merged a new 5.2.2 release should be made.